### PR TITLE
Removed Semantic MediaWiki as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "mediawiki/semantic-signup",
 	"type": "mediawiki-extension",
-	"description": "A Semantic Mediawiki extension to support user registration semantically.",
+	"description": "An extension, based around Semantic Forms, that provides a user registration form.",
 	"keywords": [
 		"smw",
 		"semantic mediawiki",
@@ -11,7 +11,7 @@
 		"structured registration",
 		"workflow"
 	],
-	"homepage": "https://semantic-mediawiki.org/wiki/Extension:SemanticSignup",
+	"homepage": "https://www.mediawiki.org/wiki/Extension:SemanticSignup",
 	"license": "GPL-3.0+",
 	"authors": [],
 	"support": {
@@ -25,11 +25,9 @@
 	"require": {
 		"php": ">=5.3.0",
 		"composer/installers": "1.*,>=1.0.1",
-		"mediawiki/semantic-media-wiki": "~1.9|~2.0",
 		"mediawiki/semantic-forms": "~2.8|~3.0"
 	},
 	"require-dev": {
-		"mediawiki/semantic-media-wiki": "@dev"
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
As noted in the comments for the README change, this file too needs to be changed; assuming that there's agreement that Semantic MediaWiki is not in fact a requirement. I also modified the extension description, and changed the URL to what I assume is the correct URL.
